### PR TITLE
Strategy doesn't ignore additional authorization params

### DIFF
--- a/lib/passport-auth0-openidconnect/strategy.js
+++ b/lib/passport-auth0-openidconnect/strategy.js
@@ -40,7 +40,19 @@ function Strategy(options, verify) {
   OpenIDConnectStrategy.call(this, options, verify);
 
   this.name = 'auth0-oidc';
-  
+}
+
+/**
+ * Return extra parameters to be included in the authorization request.
+ *
+ * Allows client code to override authorization params.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function (options) {
+  return options || {};
 }
 
 /**


### PR DESCRIPTION
User provided authorization params (e.g. `prompt`) are not ignored.

This override passport-auth0-openidconnect's [`authorizationParams()`](https://github.com/siacomuzzi/passport-openidconnect/blob/master/lib/strategy.js#L338).

[Fixes #3](https://github.com/auth0/passport-auth0-openidconnect/issues/3)